### PR TITLE
small fixes for the website

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -21,17 +21,14 @@ body a {
 	text-decoration: none;
 	color: #AE1800;
 }
-body a:hover {
-	text-decoration: none;
+body a:focus, a:hover, a:visited {
 	color: #404040;
 }
-body a:visited {
-	text-decoration: none;
-	color: #8C8C8C;
+body a:focus {
+	text-decoration: underline;
 }
-
-body a:focus, a:hover {
-	text-decoration: none;
+body a:not([href]) {
+	color: #8C8C8C;
 }
 input[type="button"], input[type="submit"] {
 	transition: 0.5s all;

--- a/js/alumni.js
+++ b/js/alumni.js
@@ -1,7 +1,11 @@
 function aggregateAlumni(W) {
     var s_w = "<ul>\n";
     for (let i = 0; i < W.length; ++i) {
-	s_w += `  <li><a href="${W[i][1]}">${W[i][0]}</a></li>\n`;
+        if (`${W[i][1]}`==""){ 	
+            s_w += `  <li><a>${W[i][0]}</a></li>\n`;
+        }else{
+            s_w += `  <li><a href="${W[i][1]}">${W[i][0]}</a></li>\n`;
+        }
     }
     s_w += "</ul>\n";
     return s_w;

--- a/snail.html
+++ b/snail.html
@@ -42,9 +42,9 @@ License URL: http://creativecommons.org/licenses/by/3.0/
 			</div>
 			<div id="navbar" class="navbar-collapse collapse">
 				<ul class="nav navbar-nav navbar-right">
-					<li class="active"><a href="index.html">HOME</a></li>
+					<li><a href="index.html">HOME</a></li>
 					<li><a href="index.html#about">ABOUT</a></li>
-					<li><a href="index.html#seminars">SEMINARS</a></li>
+					<li class="active"><a href="index.html#seminars">SEMINARS</a></li>
 					<li><a href="index.html#faculty">FACULTY</a></li>
 					<li><a href="index.html#members">MEMBERS</a></li>
 					<li><a href="index.html#contact">CONTACT</a></li>


### PR DESCRIPTION
 - [fix active page in snail navbar](https://github.com/LIAMF-USP/liamf-usp.github.io/commit/ff9770e62d585efbbdd4570243d50029516c768d)

 - [remove href from alumni with no page](https://github.com/LIAMF-USP/liamf-usp.github.io/commit/d2037869fea19eefd5d599c7a41c4a208d11a654)

 - [properly style alumni with no href, a11y on focus](https://github.com/LIAMF-USP/liamf-usp.github.io/commit/d9542ec9bbd190ea9d7ba560ed7b3dd9155121e5)

      - by removing href, all alumni where stilled the same whether or not they had an external link. This commit fixes this issue and redefines the visited link styling to better differentiate visited links from alumni with no links. Additionally, to improve accessibility we added styling for links with a focus state.